### PR TITLE
Feature/option storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # How to use
 
-The program can be installed by running the `install` bash script (optionally include `--user` to install locally)
+In order to build the project locally, cd into the sootty directory and run:
 
-Run:
+    python3 -m pip install .
+
+To use, run:
 
     sootty waveform.vcd > image.svg
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ Display wires `Data` and `D1` for 8 units of time starting when `Data` is equal 
 
 How to run in python:
 
-    from sootty import WireTrace
+    from sootty import WireTrace, Visualizer, Style
 
     # Create wiretrace object from vcd file:
     wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
     # Convert wiretrace to svg:
-    svg_data = wiretrace.to_svg(start=0, length=8)
+    image = Visualizer(Style.Dark).to_svg(wiretrace, start=0, length=8)
     
     # Display to stdout:
-    wiretrace.display(start=0, length=8)
+    image.display()
 
 # Dependencies:
 

--- a/install
+++ b/install
@@ -1,3 +1,2 @@
 #! /bin/bash
-
-python3 setup.py clean --all install "$@"
+python3 -m pip install .

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,27 @@
+import pathlib
 import setuptools 
 
+# The directory containing this file
+HERE = pathlib.Path(__file__).parent
+
+# The text of the README file
+README = (HERE / "README.md").read_text()
+
+
 setuptools.setup( 
-    name='sootty', 
+    name='sootty',
     version='0.1',
-    description='Converts vcd files into svg', 
-    packages=setuptools.find_packages(), 
+    description='Displays vcd files to the command line.', 
+    long_description=README,
+    packages=setuptools.find_packages(exclude=("tests",)), 
+    long_description_content_type="text/markdown",
+    url="https://github.com/Ben1152000/sootty",
+    author="Ben Darnell",
+    author_email="ben@bdarnell.com",
+    license="BSD",
     entry_points={ 
         'console_scripts': [ 
-            'sootty = sootty.main:main'
+            'sootty = sootty.__main__:main'
         ] 
     },
     package_data={
@@ -15,6 +29,7 @@ setuptools.setup(
     },
     install_requires=[
         'lark',
+        'pyDigitalWaveTools'
     ],
     dependency_links=[
         'https://github.com/Nic30/pyDigitalWaveTools.git'

--- a/sootty/__init__.py
+++ b/sootty/__init__.py
@@ -1,13 +1,10 @@
 from .main import main
 
-from .display import display
+from .display import VectorImage
 
-from .visualizer import Visualizer
-from .visualizer import Style
-from .visualizer import LightStyle
-from .visualizer import SiliconStyle
+from .exceptions import SoottyError
+from .exceptions import SoottyInternalError
 
-from .wiretrace import Wire
-from .wiretrace import WireGroup
-from .wiretrace import WireTrace
-from .wiretrace import TraceError
+from .visualizer import Visualizer, Style
+
+from .wiretrace import Wire, WireGroup, WireTrace

--- a/sootty/__init__.py
+++ b/sootty/__init__.py
@@ -1,5 +1,3 @@
-from .main import main
-
 from .display import VectorImage
 
 from .exceptions import SoottyError

--- a/sootty/__init__.py
+++ b/sootty/__init__.py
@@ -2,6 +2,11 @@ from .main import main
 
 from .display import display
 
+from .visualizer import Visualizer
+from .visualizer import Style
+from .visualizer import LightStyle
+from .visualizer import SiliconStyle
+
 from .wiretrace import Wire
 from .wiretrace import WireGroup
 from .wiretrace import WireTrace

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -50,3 +50,6 @@ def main():
     
     else:
         print(image.source)
+
+if __name__ == "__main__":
+    main()

--- a/sootty/display.py
+++ b/sootty/display.py
@@ -1,6 +1,13 @@
 from sys import stdout
 from subprocess import call, Popen, STDOUT, PIPE
 
-def display(svg_data):
-    process = Popen("rsvg-convert -x 4 -y 4 | viu -", shell=True, stdin=PIPE, stdout=stdout)
-    process.communicate(input=str.encode(svg_data))
+
+class VectorImage:
+    """Encapsulates logic to store and display an SVG to the terminal."""
+
+    def __init__(self, source):
+        self.source = source
+
+    def display(self):
+        process = Popen("rsvg-convert -x 4 -y 4 | viu -", shell=True, stdin=PIPE, stdout=stdout)
+        process.communicate(input=str.encode(self.source))

--- a/sootty/exceptions.py
+++ b/sootty/exceptions.py
@@ -1,0 +1,9 @@
+
+class SoottyError(Exception):
+    """ Raised on any user-facing error in this module. """
+    pass
+
+
+class SoottyInternalError(Exception):
+    """ Raised on any Sootty internal failure. """
+    pass

--- a/sootty/limits.py
+++ b/sootty/limits.py
@@ -5,11 +5,13 @@ try:
 except ImportError:
     import importlib_resources as pkg_resources
 
+# Read and interpret grammar file.
 from . import static
 parser = Lark(pkg_resources.open_text(static, "grammar.lark").read())
 
 
 class Prune(Visitor):
+    """Visitor class used to prune the parse tree to make it easier to interpret."""
 
     def binexp(self, tree):
         if len(tree.children) == 1:
@@ -53,16 +55,10 @@ class Prune(Visitor):
             tree.data = tree.children[1].children[0]
             tree.children = [tree.children[0], tree.children[2]]
 
+
 class LimitExpression:
+    """Parses an expression representing the limits of a wiretrace window."""
 
     def __init__(self, expression):
         parsed = parser.parse(expression)
         self.tree = Prune().visit(parsed)
-
-if __name__ == "__main__":
-
-    print(LimitExpression("a + b & c - d + const 1").tree.pretty(' '))
-
-    print(LimitExpression("after (acc clk == const 5) & ready & value & (3 next data == const 64)").tree)
-
-    print(LimitExpression("D1 & D2").tree)

--- a/sootty/main.py
+++ b/sootty/main.py
@@ -2,6 +2,7 @@ import sys, argparse
 
 from .display import display
 from .wiretrace import WireTrace
+from .visualizer import Visualizer
 
 def main():
 
@@ -36,7 +37,7 @@ def main():
     if args.wires:
         wires = set(args.wires.split(','))
     
-    svg_data = wiretrace.to_svg(start=start, length=length, wires=wires)
+    svg_data = Visualizer().to_svg(wiretrace, start=start, length=length, wires=wires)
 
     if len(wires):
         raise Exception(f'Unknown wires {wires.__repr__()}\nThe following wires were detected in the wiretrace:\n{wiretrace.get_wire_names()}')

--- a/sootty/main.py
+++ b/sootty/main.py
@@ -1,6 +1,5 @@
 import sys, argparse
 
-from .display import display
 from .wiretrace import WireTrace
 from .visualizer import Visualizer
 
@@ -15,11 +14,14 @@ def main():
     parser.add_argument('-w', '--wires', type=str, metavar='LIST', dest='wires', help='comma-separated list of wires to view')
     args = parser.parse_args()
 
+    # Load vcd file into wiretrace object.
     wiretrace = WireTrace.from_vcd_file(args.filename)
 
+    # Check that window bounds are well-defined.
     if args.end is not None and args.length is not None:
         raise Exception('Length and end flags should not be provided simultaneously.')
     
+    # Calculate window bounds.
     if args.end is not None:
         if args.start is not None:
             start, end = wiretrace.compute_limits(args.start, args.end)
@@ -37,13 +39,14 @@ def main():
     if args.wires:
         wires = set(args.wires.split(','))
     
-    svg_data = Visualizer().to_svg(wiretrace, start=start, length=length, wires=wires)
+    # Convert wiretrace to graphical vector image.
+    image = Visualizer().to_svg(wiretrace, start=start, length=length, wires=wires)
 
     if len(wires):
         raise Exception(f'Unknown wires {wires.__repr__()}\nThe following wires were detected in the wiretrace:\n{wiretrace.get_wire_names()}')
     
     if args.display:
-        display(svg_data)
+        image.display()
     
     else:
-        print(svg_data)
+        print(image.source)

--- a/sootty/visualizer.py
+++ b/sootty/visualizer.py
@@ -1,6 +1,8 @@
 import sys
-class Visualizer:
+from .display import display
 
+
+class Style:
     TOP_MARGIN = 15
     LEFT_MARGIN = 15
     TEXT_WIDTH = 100
@@ -10,56 +12,75 @@ class Visualizer:
     TRANS_START = 5
     TRANS_WIDTH = 5
     BLOCK_TRANS = False
+    LINE_COLOR = "#FFFFFF"
+    TEXT_COLOR = "#FFFFFF"
+    BKGD_COLOR = "#000000"
+
+
+class DarkStyle(Style):
+    pass
+
+
+class LightStyle(Style):
     LINE_COLOR = "#000000"
     TEXT_COLOR = "#000000"
     BKGD_COLOR = "#FFFFFF"
 
-    @staticmethod
-    def wiretrace_to_svg(wiretrace, start=0, length=1, wires=set()):
-        width = 2 * Visualizer.LEFT_MARGIN + Visualizer.TEXT_WIDTH + length * Visualizer.DATA_WIDTH
-        height = 2 * Visualizer.TOP_MARGIN + (len(wires) + 1) * (Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN) - Visualizer.WIRE_MARGIN
+
+class SiliconStyle(Style):
+    LINE_COLOR = "#B0B0B0"
+    TEXT_COLOR = "#30FF30"
+    BKGD_COLOR = "#003000"
+
+
+class Visualizer:
+
+    def __init__(self, style=Style):
+        self.style = style
+    
+    def _wiretrace_to_svg(self, wiretrace, start, length, wires=None):
+        width = 2 * self.style.LEFT_MARGIN + self.style.TEXT_WIDTH + length * self.style.DATA_WIDTH
+        height = 2 * self.style.TOP_MARGIN + (len(wires) + 1) * (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN) - self.style.WIRE_MARGIN
         if len(wires) == 0:
             wires = None
-            height += sum([sum([1 for wire in wiregroup.wires]) for wiregroup in wiretrace.wiregroups]) * (Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN)
+            height += sum([sum([1 for wire in wiregroup.wires]) for wiregroup in wiretrace.wiregroups]) * (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN)
         
         svg = f'<svg viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">' \
-              f'<rect x="0" y="0" width="{width}" height="{height}" fill="{Visualizer.BKGD_COLOR}" />'
+              f'<rect x="0" y="0" width="{width}" height="{height}" fill="{self.style.BKGD_COLOR}" />'
         
         lines = 1
-        svg += Visualizer.timestamps_to_svg(
-            left = Visualizer.LEFT_MARGIN + Visualizer.TEXT_WIDTH, 
-            top = Visualizer.TOP_MARGIN,
+        svg += self._timestamps_to_svg(
+            left = self.style.LEFT_MARGIN + self.style.TEXT_WIDTH, 
+            top = self.style.TOP_MARGIN,
             start = start,
             length = length)
         
         for wiregroup in wiretrace.wiregroups:
-            svg += Visualizer.wiregroup_to_svg(
+            svg += self._wiregroup_to_svg(
                 wiregroup = wiregroup, 
-                left = Visualizer.LEFT_MARGIN,
-                top = Visualizer.TOP_MARGIN + Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN,
+                left = self.style.LEFT_MARGIN,
+                top = self.style.TOP_MARGIN + self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN,
                 start = start,
                 length = length,
                 wires = wires)
         svg += '</svg>'
         return svg
 
-    @staticmethod
-    def timestamps_to_svg(left, top, start, length):
+    def _timestamps_to_svg(self, left, top, start, length):
         svg = ''
         for index in range(start, start + length):
-            svg += f'<text x="{left + (index - start + 1/2) * Visualizer.DATA_WIDTH}" y="{top + (Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN) / 2}" class="small" fill="{Visualizer.TEXT_COLOR}" text-anchor="middle">{index}</text>'
+            svg += f'<text x="{left + (index - start + 1/2) * self.style.DATA_WIDTH}" y="{top + (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN) / 2}" class="small" fill="{self.style.TEXT_COLOR}" text-anchor="middle">{index}</text>'
         return svg
 
-    @staticmethod
-    def wiregroup_to_svg(wiregroup, left, top, start, length, wires=None):
+    def _wiregroup_to_svg(self, wiregroup, left, top, start, length, wires=None):
         svg = ''
         index = 0
         for wire in wiregroup.wires:
             if wires == None or wire.name in wires:
-                svg += Visualizer.wire_to_svg(
+                svg += self._wire_to_svg(
                     wire,
                     left = left,
-                    top = top + (index * (Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN)),
+                    top = top + (index * (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN)),
                     start = start,
                     length = length)
                 if wires:
@@ -67,64 +88,70 @@ class Visualizer:
                 index += 1
         return svg
 
-    @staticmethod
-    def wire_to_svg(wire, left, top, start, length):
-        svg = f'<text x="{left}" y="{top + 15}" class="small" fill="{Visualizer.TEXT_COLOR}">{wire.name}</text>'
+    def _wire_to_svg(self, wire, left, top, start, length):
+        svg = f'<text x="{left}" y="{top + 15}" class="small" fill="{self.style.TEXT_COLOR}">{wire.name}</text>'
         for index in range(start, start + length):
             prev = (wire.data[index - 1] if index > 0 else wire.data[index]) if index < len(wire.data) else wire.data[-1]
             value = wire.data[index] if index < len(wire.data) else wire.data[-1]
-            svg += Visualizer.value_to_svg(
+            svg += self._value_to_svg(
                 prev = bool(prev) if wire.width == 1 else prev,
                 value = bool(value) if wire.width == 1 else value,
-                left = left + ((index - start) * Visualizer.DATA_WIDTH) + Visualizer.TEXT_WIDTH,
+                left = left + ((index - start) * self.style.DATA_WIDTH) + self.style.TEXT_WIDTH,
                 top = top,
                 initial = (index == start))
         return svg
 
-    @staticmethod
-    def value_to_svg(prev, value, left, top, initial=False):
+    def _value_to_svg(self, prev, value, left, top, initial=False):
         prev_type = 'low' if prev is False else ('high' if prev is True else 'data')
         value_type = 'low' if value is False else ('high' if value is True else 'data')
         is_transitioning = (prev != value)
 
         if prev_type == 'low' and value_type == 'low':
-            return f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'low' and value_type == 'high':
-            return f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH * Visualizer.BLOCK_TRANS}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH * Visualizer.BLOCK_TRANS}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH * self.style.BLOCK_TRANS}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH * self.style.BLOCK_TRANS}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'low' and value_type == 'data':
-            return f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'high' and value_type == 'low':
-            return f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH * Visualizer.BLOCK_TRANS}" y1="{top}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH * Visualizer.BLOCK_TRANS}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH * self.style.BLOCK_TRANS}" y1="{top}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH * self.style.BLOCK_TRANS}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'high' and value_type == 'high':
-            return f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'high' and value_type == 'data':
-            return f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'data' and value_type == 'low':
-            return f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'data' and value_type == 'high':
-            return f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'data' and value_type == 'data' and not is_transitioning and not initial:
-            return f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />'
+            return f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />'
         elif prev_type == 'data' and value_type == 'data':
-            return f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left}" x2="{left + Visualizer.TRANS_START}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top + Visualizer.WIRE_HEIGHT}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START}" x2="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" y1="{top + Visualizer.WIRE_HEIGHT}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<line x1="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH}" x2="{left + Visualizer.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{Visualizer.LINE_COLOR}" />' \
-                   f'<text x="{left + Visualizer.TRANS_START + Visualizer.TRANS_WIDTH + 5}" y="{top + (Visualizer.WIRE_HEIGHT + Visualizer.WIRE_MARGIN) / 2}" class="small" fill="{Visualizer.TEXT_COLOR}">{"X" if value == None else hex(value)}</text>'
+            return f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" x2="{left + self.style.DATA_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left}" x2="{left + self.style.TRANS_START}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top + self.style.WIRE_HEIGHT}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START}" x2="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" y1="{top + self.style.WIRE_HEIGHT}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
+                   f'<text x="{left + self.style.TRANS_START + self.style.TRANS_WIDTH + 5}" y="{top + (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN) / 2}" class="small" fill="{self.style.TEXT_COLOR}">{"X" if value == None else hex(value)}</text>'
         else:
             return 'ERROR'
+
+    def to_svg(self, wiretrace, start=0, length=1, wires=set()):
+        """Converts the provided wiretrace object to an svg."""
+        return self._wiretrace_to_svg(wiretrace, start, length, wires)
+
+    def display(self, wiretrace, start=0, length=1, wires=set()):
+        """Displays the provided wiretrace object to the terminal."""
+        display(self.to_svg(wiretrace, start, length, wires))

--- a/sootty/visualizer.py
+++ b/sootty/visualizer.py
@@ -1,43 +1,51 @@
 import sys
-from .display import display
+
+from .display import VectorImage
+from .exceptions import SoottyInternalError
 
 
 class Style:
-    TOP_MARGIN = 15
-    LEFT_MARGIN = 15
-    TEXT_WIDTH = 100
-    DATA_WIDTH = 50
-    WIRE_HEIGHT = 20
-    WIRE_MARGIN = 10
-    TRANS_START = 5
-    TRANS_WIDTH = 5
-    BLOCK_TRANS = False
-    LINE_COLOR = "#FFFFFF"
-    TEXT_COLOR = "#FFFFFF"
-    BKGD_COLOR = "#000000"
+    """Container class for visualizer style settings."""
 
+    class Default():
+        TOP_MARGIN = 15
+        LEFT_MARGIN = 15
+        TEXT_WIDTH = 100
+        DATA_WIDTH = 50
+        WIRE_HEIGHT = 20
+        WIRE_MARGIN = 10
+        TRANS_START = 5
+        TRANS_WIDTH = 5
+        BLOCK_TRANS = False
+        LINE_COLOR = "#FFFFFF"
+        TEXT_COLOR = "#FFFFFF"
+        BKGD_COLOR = "#000000"
 
-class DarkStyle(Style):
-    pass
+    class Dark(Default):
+        pass
 
+    class Light(Default):
+        LINE_COLOR = "#000000"
+        TEXT_COLOR = "#000000"
+        BKGD_COLOR = "#FFFFFF"
 
-class LightStyle(Style):
-    LINE_COLOR = "#000000"
-    TEXT_COLOR = "#000000"
-    BKGD_COLOR = "#FFFFFF"
-
-
-class SiliconStyle(Style):
-    LINE_COLOR = "#B0B0B0"
-    TEXT_COLOR = "#30FF30"
-    BKGD_COLOR = "#003000"
+    class Silicon(Default):
+        LINE_COLOR = "#B0B0B0"
+        TEXT_COLOR = "#30FF30"
+        BKGD_COLOR = "#003000"
 
 
 class Visualizer:
+    """Converter for wiretrace objects to a svg vector image format."""
 
-    def __init__(self, style=Style):
+    def __init__(self, style=Style.Default):
+        """Optionally pass in a style class to control how the visualizer looks."""
         self.style = style
-    
+
+    def to_svg(self, wiretrace, start=0, length=1, wires=set()):
+        """Converts the provided wiretrace object to a VectorImage object (svg)."""
+        return VectorImage(self._wiretrace_to_svg(wiretrace, start, length, wires))
+
     def _wiretrace_to_svg(self, wiretrace, start, length, wires=None):
         width = 2 * self.style.LEFT_MARGIN + self.style.TEXT_WIDTH + length * self.style.DATA_WIDTH
         height = 2 * self.style.TOP_MARGIN + (len(wires) + 1) * (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN) - self.style.WIRE_MARGIN
@@ -146,12 +154,4 @@ class Visualizer:
                    f'<line x1="{left + self.style.TRANS_START + self.style.TRANS_WIDTH}" x2="{left + self.style.DATA_WIDTH}" y1="{top}" y2="{top}" stroke="{self.style.LINE_COLOR}" />' \
                    f'<text x="{left + self.style.TRANS_START + self.style.TRANS_WIDTH + 5}" y="{top + (self.style.WIRE_HEIGHT + self.style.WIRE_MARGIN) / 2}" class="small" fill="{self.style.TEXT_COLOR}">{"X" if value == None else hex(value)}</text>'
         else:
-            return 'ERROR'
-
-    def to_svg(self, wiretrace, start=0, length=1, wires=set()):
-        """Converts the provided wiretrace object to an svg."""
-        return self._wiretrace_to_svg(wiretrace, start, length, wires)
-
-    def display(self, wiretrace, start=0, length=1, wires=set()):
-        """Displays the provided wiretrace object to the terminal."""
-        display(self.to_svg(wiretrace, start, length, wires))
+            raise SoottyInternalError("Invalid wire transition, unable to visualize.")

--- a/sootty/wiretrace.py
+++ b/sootty/wiretrace.py
@@ -1,13 +1,9 @@
 import json
 from pyDigitalWaveTools.vcd.parser import VcdParser
 
-from .display import display
+from .exceptions import SoottyInternalError
 from .limits import LimitExpression
-from .visualizer import Visualizer
 
-class TraceError(Exception):
-    """ Raised on any user-facing error in this module. """
-    pass
 
 class Wire:
 
@@ -343,6 +339,7 @@ class Wire:
             data=data
         )
 
+
 class WireGroup:
 
     def __init__(self, name):
@@ -372,6 +369,7 @@ class WireGroup:
                     WireGroup.from_vcd(child, name)
                 )
         return wiregroup
+
 
 class WireTrace:
 
@@ -412,7 +410,7 @@ class WireTrace:
             for wire in wiregroup.wires:
                 if wire.name == name:
                     return wire
-        raise TraceError(f"Wire '{name}' does not exist.")
+        raise SoottyInternalError(f"Wire '{name}' does not exist.")
     
     def get_wire_names(self):
         names = []

--- a/sootty/wiretrace.py
+++ b/sootty/wiretrace.py
@@ -485,9 +485,3 @@ class WireTrace:
         except ValueError:
             end = self.length()
         return (start, end)
-
-    def to_svg(self, start=0, length=1, wires=set()):
-        return Visualizer.wiretrace_to_svg(self, start, length, wires)
-
-    def display(self, start=0, length=1, wires=set()):
-        display(self.to_svg(start, length, wires))

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,18 +1,18 @@
 import re, sys
 from subprocess import call, Popen, STDOUT, PIPE
 
-from sootty import WireTrace
+from sootty import WireTrace, Visualizer, display
 
 wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
 assert type(wiretrace) == WireTrace
 
-svg_data = wiretrace.to_svg(start=0, length=8)
+svg_data = Visualizer().to_svg(wiretrace, start=0, length=8)
 
 pattern = r'(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b'
 prog = re.compile(pattern, re.DOTALL)
 assert prog.match(svg_data) is not None
 
-wiretrace.display(start=0, length=8)
+display(svg_data)
 
 print("Success!")

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,18 +1,18 @@
 import re, sys
 from subprocess import call, Popen, STDOUT, PIPE
 
-from sootty import WireTrace, Visualizer, display
+from sootty import WireTrace, Visualizer, VectorImage
 
 wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
 assert type(wiretrace) == WireTrace
 
-svg_data = Visualizer().to_svg(wiretrace, start=0, length=8)
+image = Visualizer().to_svg(wiretrace, start=0, length=8)
 
 pattern = r'(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b'
 prog = re.compile(pattern, re.DOTALL)
-assert prog.match(svg_data) is not None
+assert prog.match(image.source) is not None
 
-display(svg_data)
+image.display()
 
 print("Success!")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,10 @@
+from sootty.limits import LimitExpression
+
+
+assert str(LimitExpression("a + b & c - d + const 1").tree.pretty('\t')) == "&\n\t+\n\t\twire\ta\n\t\twire\tb\n\t+\n\t\t-\n\t\t\twire\tc\n\t\t\twire\td\n\t\tconst\t1\n"
+
+assert str(LimitExpression("after (acc clk == const 5) & ready & value & (3 next data == const 64)").tree.pretty('\t')) == "&\n\t&\n\t\t&\n\t\t\tafter\n\t\t\t\t==\n\t\t\t\t\tacc\n\t\t\t\t\t\twire\tclk\n\t\t\t\t\tconst\t5\n\t\t\twire\tready\n\t\twire\tvalue\n\t==\n\t\tnext\n\t\t\t3\n\t\t\twire\tdata\n\t\tconst\t64\n"
+
+assert str(LimitExpression("D1 & D2").tree.pretty('\t')) == "&\n\twire\tD1\n\twire\tD2\n"
+
+print('Success!')

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,7 +1,11 @@
-from sootty import WireTrace, Visualizer, display, SiliconStyle
+from sootty import WireTrace, Visualizer, Style
 
 wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
-svg_data = Visualizer(SiliconStyle).to_svg(wiretrace, start=0, length=8)
+Visualizer(Style.Silicon).to_svg(wiretrace, start=0, length=8).display()
 
-display(svg_data)
+Visualizer(Style.Dark).to_svg(wiretrace, start=0, length=8).display()
+
+Visualizer(Style.Light).to_svg(wiretrace, start=0, length=8).display()
+
+print("Success!")

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,7 @@
+from sootty import WireTrace, Visualizer, display, SiliconStyle
+
+wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
+
+svg_data = Visualizer(SiliconStyle).to_svg(wiretrace, start=0, length=8)
+
+display(svg_data)


### PR DESCRIPTION
This PR includes a significant refactor of the code-base up to this point, moving functionality around, adding test cases, and introducing a Style class. This class keeps track of the styling options used by the Visualizer, and can be easily extended to create custom styles. Here is the new way to use sootty from the REPL:

    from sootty import WireTrace, Visualizer, Style

    # Create wiretrace object from vcd file:
    wiretrace = WireTrace.from_vcd_file("example/example1.vcd")

    # Convert wiretrace to svg:
    image = Visualizer(Style.Dark).to_svg(wiretrace, start=0, length=8)
    
    # Display to stdout:
    image.display()

The limit expressions might also be stored somehow, but they would anyway have to be recomputed for the new wiretrace. I'm not sure if this fully closes #11, input would be appreciated :-)