### PR TITLE
Add PyRTL integration to sootty

### DIFF
--- a/sootty/display.py
+++ b/sootty/display.py
@@ -8,6 +8,9 @@ class VectorImage:
     def __init__(self, source):
         self.source = source
 
+    def __str__(self):
+        return self.source
+    
     def display(self):
         process = Popen("rsvg-convert -x 4 -y 4 | viu -", shell=True, stdin=PIPE, stdout=stdout)
         process.communicate(input=str.encode(self.source))

--- a/sootty/visualizer.py
+++ b/sootty/visualizer.py
@@ -42,7 +42,9 @@ class Visualizer:
         """Optionally pass in a style class to control how the visualizer looks."""
         self.style = style
 
-    def to_svg(self, wiretrace, start=0, length=1, wires=set()):
+    def to_svg(self, wiretrace, start=0, length=None, wires=set()):
+        if length is None:
+            length = wiretrace.length()
         """Converts the provided wiretrace object to a VectorImage object (svg)."""
         return VectorImage(self._wiretrace_to_svg(wiretrace, start, length, wires))
 

--- a/sootty/wiretrace.py
+++ b/sootty/wiretrace.py
@@ -396,6 +396,23 @@ class WireTrace:
             )
         return wiretrace
 
+    @staticmethod
+    def from_pyrtl(sim_trace):
+        """Parses a WireTrace object from a PyRTL SimulationTrace object.
+
+        :param SimulationTrace sim_trace: The object that stores the PyRTL tracer.
+        """
+        wiretrace = WireTrace()
+        wiregroup = WireGroup('main')
+        for wirename in sim_trace.trace:
+            wiregroup.add_wire(Wire(
+                name = wirename,
+                width = sim_trace._wires[wirename].bitwidth,
+                data = sim_trace.trace[wirename]
+            ))
+        wiretrace.add_wiregroup(wiregroup)
+        return wiretrace
+
     # Returns the time of the last entry in data
     def length(self):
         limit = 0

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,18 +1,22 @@
 import re, sys
 from subprocess import call, Popen, STDOUT, PIPE
-
 from sootty import WireTrace, Visualizer, VectorImage
 
-wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
-assert type(wiretrace) == WireTrace
+def test_svg_output():
+    wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
-image = Visualizer().to_svg(wiretrace, start=0, length=8)
+    assert type(wiretrace) == WireTrace
 
-pattern = r'(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b'
-prog = re.compile(pattern, re.DOTALL)
-assert prog.match(image.source) is not None
+    image = Visualizer().to_svg(wiretrace, start=0, length=8)
 
-image.display()
+    pattern = r'(?:<\?xml\b[^>]*>[^<]*)?(?:<!--.*?-->[^<]*)*(?:<svg|<!DOCTYPE svg)\b'
+    prog = re.compile(pattern, re.DOTALL)
+    assert prog.match(image.source) is not None
 
-print("Success!")
+    image.display()
+
+
+if __name__ == "__main__":
+    test_svg_output()
+    print('Success!')

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,10 +1,14 @@
 from sootty.limits import LimitExpression
 
 
-assert str(LimitExpression("a + b & c - d + const 1").tree.pretty('\t')) == "&\n\t+\n\t\twire\ta\n\t\twire\tb\n\t+\n\t\t-\n\t\t\twire\tc\n\t\t\twire\td\n\t\tconst\t1\n"
+def test_limits():
+    assert str(LimitExpression("a + b & c - d + const 1").tree.pretty('\t')) == "&\n\t+\n\t\twire\ta\n\t\twire\tb\n\t+\n\t\t-\n\t\t\twire\tc\n\t\t\twire\td\n\t\tconst\t1\n"
 
-assert str(LimitExpression("after (acc clk == const 5) & ready & value & (3 next data == const 64)").tree.pretty('\t')) == "&\n\t&\n\t\t&\n\t\t\tafter\n\t\t\t\t==\n\t\t\t\t\tacc\n\t\t\t\t\t\twire\tclk\n\t\t\t\t\tconst\t5\n\t\t\twire\tready\n\t\twire\tvalue\n\t==\n\t\tnext\n\t\t\t3\n\t\t\twire\tdata\n\t\tconst\t64\n"
+    assert str(LimitExpression("after (acc clk == const 5) & ready & value & (3 next data == const 64)").tree.pretty('\t')) == "&\n\t&\n\t\t&\n\t\t\tafter\n\t\t\t\t==\n\t\t\t\t\tacc\n\t\t\t\t\t\twire\tclk\n\t\t\t\t\tconst\t5\n\t\t\twire\tready\n\t\twire\tvalue\n\t==\n\t\tnext\n\t\t\t3\n\t\t\twire\tdata\n\t\tconst\t64\n"
 
-assert str(LimitExpression("D1 & D2").tree.pretty('\t')) == "&\n\twire\tD1\n\twire\tD2\n"
+    assert str(LimitExpression("D1 & D2").tree.pretty('\t')) == "&\n\twire\tD1\n\twire\tD2\n"
 
-print('Success!')
+
+if __name__ == "__main__":
+    test_limits()
+    print('Success!')

--- a/tests/test_pyrtl.py
+++ b/tests/test_pyrtl.py
@@ -1,0 +1,107 @@
+import pyrtl
+from sootty import WireTrace, Visualizer
+
+
+def test_counter():
+    pyrtl.reset_working_block()
+
+    i = pyrtl.Input(3, 'i') 
+    counter = pyrtl.Register(3, 'counter')
+    o = pyrtl.Output(3, 'o')
+
+    update = counter + i
+    counter.next <<= update
+    o <<= counter
+
+    sim = pyrtl.Simulation()
+    sim.step_multiple({'i': [1, 1, 1, 1, 1]})
+    sim.tracer.render_trace()
+
+    wiretrace = WireTrace.from_pyrtl(sim.tracer)
+    Visualizer().to_svg(wiretrace).display()
+
+    print(pyrtl.working_block())
+
+
+def test_alu():
+    pyrtl.reset_working_block()
+
+    LW = 0
+    SW = 1
+    BEQ = 2
+    RT = 3
+    AND = 0
+    OR = 1
+    ADD = 2
+    SUB = 3
+
+    def ALU(ctrl, a, b):
+        result = pyrtl.WireVector(16)
+        zero = pyrtl.WireVector(1)
+
+        with pyrtl.conditional_assignment:
+            with ctrl == AND: 
+                result |= a & b
+            with ctrl == OR:
+                result |= a | b
+            with ctrl == ADD:
+                result |= a + b
+            with ctrl == SUB:
+                result |= a - b
+
+        zero <<= (result == 0)
+        return result, zero
+
+    def ALUControl(op, func):
+        ctrl = pyrtl.WireVector(2, "ctrl")
+        with pyrtl.conditional_assignment:
+            with op == LW:
+                ctrl |= 2
+            with op == SW:
+                ctrl |= 2
+            with op == BEQ:
+                ctrl |= 3
+            with op == RT:
+                with func == 0:
+                    ctrl |= AND
+                with func == 1:
+                    ctrl |= OR
+                with func == 2:
+                    ctrl |= ADD
+                with func == 3:
+                    ctrl |= SUB
+        return ctrl
+
+    op = pyrtl.Input(2, 'op')
+    a = pyrtl.Input(16, 'a')
+    b = pyrtl.Input(16, 'b')
+    func = pyrtl.Input(2, 'func')
+
+    r = pyrtl.Output(16, 'result')
+    z = pyrtl.Output(1, 'zero')
+
+    ctl = ALUControl(op, func)
+    r_o, z_o, = ALU(ctl, a, b)
+    r <<= r_o
+    z <<= z_o
+
+    sim_inputs = {
+        'op': [0]*2 + [1]*2 + [2]*2 + [3]*2,
+        'a': [2,1]*4,
+        'b': [1,0,1,0]*2,
+        'func': [0]*6 + [0,1]
+    }
+
+    sim = pyrtl.Simulation()
+
+    sim.step_multiple(sim_inputs)
+    sim.tracer.render_trace(trace_list=['op','func','a','b','result','zero'])
+
+    wiretrace = WireTrace.from_pyrtl(sim.tracer)
+    Visualizer().to_svg(wiretrace).display()
+
+
+if __name__ == "__main__":
+    test_counter()
+    test_alu()
+    print('Success!')

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,11 +1,17 @@
 from sootty import WireTrace, Visualizer, Style
 
-wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
-Visualizer(Style.Silicon).to_svg(wiretrace, start=0, length=8).display()
+def test_style_class():
 
-Visualizer(Style.Dark).to_svg(wiretrace, start=0, length=8).display()
+    wiretrace = WireTrace.from_vcd_file("example/example1.vcd")
 
-Visualizer(Style.Light).to_svg(wiretrace, start=0, length=8).display()
+    Visualizer(Style.Silicon).to_svg(wiretrace, start=0, length=8).display()
 
-print("Success!")
+    Visualizer(Style.Dark).to_svg(wiretrace, start=0, length=8).display()
+
+    Visualizer(Style.Light).to_svg(wiretrace, start=0, length=8).display()
+
+
+if __name__ == "__main__":
+    test_style_class()
+    print('Success!')


### PR DESCRIPTION
Added the `WireTrace.from_pyrtl()` method which takes in a PyRTL SimulationTrace object and produces a sootty WireTrace. Closes #16.