### PR TITLE
Add wire types test case

### DIFF
--- a/example/wire_types.vcd
+++ b/example/wire_types.vcd
@@ -1,0 +1,15 @@
+$date Sun Oct 24 13:51:17 2021 $end
+$version libsigrok 0.6.0-git-c03aaf342c3f $end
+$comment
+Testing all possible one-bit values in verilog: 00110XX1X0ZZXZ1Z0
+$end
+$timescale 1 us $end
+$scope module libsigrok $end
+$var wire 1 ! wire $end
+$upscope $end
+$enddefinitions $end
+
+ #0 b0 !  #1 b0 ! 
+ #2 b1 !  #3 b1 !  #4 b0 ! 
+ #5 bX !  #6 bX !  #7 b1 !  #8 bX !  #9 b0 ! 
+#10 bZ ! #11 bZ ! #12 bX ! #13 bZ ! #14 b1 ! #15 bZ ! #16 b0 !

--- a/tests/test_wire_types.py
+++ b/tests/test_wire_types.py
@@ -1,0 +1,12 @@
+import pyrtl
+from sootty import WireTrace, Visualizer
+
+
+def test_data_types():
+    wiretrace = WireTrace.from_vcd_file("example/wire_types.vcd")
+    Visualizer().to_svg(wiretrace).display()
+
+
+if __name__ == "__main__":
+    test_data_types()
+    print('Success!')


### PR DESCRIPTION
Add useful test case for working on the visualizer. This tests all combinations of '0', '1', 'X', and 'Z' on a 1-bit wire.