### PR TITLE
Fix LABEL_WIDTH setting

### DIFF
--- a/sootty/visualizer.py
+++ b/sootty/visualizer.py
@@ -1,4 +1,4 @@
-import sys
+import sys, html
 from enum import Enum
 
 from .display import VectorImage
@@ -12,8 +12,8 @@ class Style:
         TOP_MARGIN = 15
         LEFT_MARGIN = 15
         CHAR_WIDTH = 7
-        LABEL_WIDTH = 12
-        TEXT_WIDTH = CHAR_WIDTH * LABEL_WIDTH
+        LABEL_WIDTH = 10
+        TEXT_WIDTH = CHAR_WIDTH * (LABEL_WIDTH + 2)
         FULL_WIDTH = 800
         WIRE_HEIGHT = 20
         WIRE_MARGIN = 10
@@ -200,7 +200,11 @@ class Visualizer:
                 "class": "small",
                 "fill": self.style.TEXT_COLOR,
                 "font-family": "monospace",
-                "content": wire.name if len(wire.name) <= 10 else wire.name[:7] + "...",
+                "content": html.escape(
+                    wire.name
+                    if len(wire.name) <= self.style.LABEL_WIDTH
+                    else wire.name[: max(self.style.LABEL_WIDTH - 3, 0)] + "..."
+                ),
             }
         )
         for index in range(start, start + length):


### PR DESCRIPTION
This setting in the default Style class allows the user to set the maximum number of characters in the wire's label. Previously the setting existed but the value was hard-coded into the Visualizer class.