### PR TITLE
YAML save file implementation along with other fixes

### DIFF
--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -153,11 +153,10 @@ def compile_query(filename, wires, breakpoints, length, start, end, display):
         length = length if length is not None else wiretrace.length() - start
 
     # Calculate breakpoints
-    breakpoints = None
     if breakpoints is not None:
         breakpoints = wiretrace.evaluate(breakpoints)
 
-    if wires:
+    if wires is not None:
         wires = set([name.strip() for name in wires.split(",")])
 
     # Convert wiretrace to graphical vector image.

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -118,7 +118,7 @@ def main():
             parser.print_usage()
             exit(0)
 
-    compile(
+    compile_query(
         args.filename,
         args.wires,
         args.breakpoints,
@@ -129,7 +129,7 @@ def main():
     )
 
 
-def compile(filename, wires, breakpoints, length, start, end, display):
+def compile_query(filename, wires, breakpoints, length, start, end, display):
 
     # Load vcd file into wiretrace object.
     wiretrace = WireTrace.from_vcd(filename)
@@ -190,8 +190,6 @@ def reload_query(
         cmd = dat[reload]["query"]
     args = parser.parse_args(shlex.split(cmd))  # using shlex to parse string correctly
 
-    print(args)
-
     # Updating specifc flags for a relaoded query
 
     if filename is not None:
@@ -207,14 +205,12 @@ def reload_query(
     if end is not None:
         args.end = end
 
-    print(args)
-
     if length is not None and end is not None:
         raise SoottyError(
             f"Length and end flags should not be provided simultaneously."
         )
 
-    compile(
+    compile_query(
         args.filename,
         args.wires,
         args.breakpoints,

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -1,4 +1,4 @@
-import sys, argparse
+import argparse
 import os, shlex
 import yaml
 from sootty.exceptions import SoottyError

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -1,5 +1,6 @@
 import sys, argparse
 import os, shlex
+import yaml
 from sootty.exceptions import SoottyError
 from . import save as sv
 from .storage import WireTrace
@@ -12,6 +13,8 @@ def main():
     if os.path.isdir(reload_path) is False:
         os.makedirs(reload_path)
 
+    savefile = reload_path + "queries.yaml"
+    
     parser = argparse.ArgumentParser(
         description="Converts .vcd wiretraces to .svg format."
     )
@@ -97,7 +100,7 @@ def main():
         )
 
     if args.reload is not None:
-        reload_query(parser, args.reload, reload_path)
+        reload_query(parser, args.reload, savefile)
         exit(0)
     else:
         if args.filename is None:
@@ -163,10 +166,15 @@ def compile(filename, wires, breakpoints, length, start, end, display):
         print(image.source)
 
 
-def reload_query(parser, reload, reload_path):
-    reload = reload_path + reload
-    with open(reload, "r") as rf:
-        cmd = rf.readline()
+def reload_query(parser, reload, savefile):
+    with open(savefile, "r") as stream:
+        try:
+            dat = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+            parser.print_usage()
+            exit(1)
+        cmd = dat[reload]["query"]
     args = parser.parse_args(shlex.split(cmd))  # using shlex to parse string correctly
 
     compile(

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -100,7 +100,18 @@ def main():
         )
 
     if args.reload is not None:
-        reload_query(parser, args.reload, savefile)
+        reload_query(
+            parser,
+            args.filename,
+            args.wires,
+            args.breakpoints,
+            args.length,
+            args.start,
+            args.end,
+            args.display,
+            args.reload,
+            savefile,
+        )
         exit(0)
     else:
         if args.filename is None:
@@ -166,7 +177,9 @@ def compile(filename, wires, breakpoints, length, start, end, display):
         print(image.source)
 
 
-def reload_query(parser, reload, savefile):
+def reload_query(
+    parser, filename, wires, breakpoints, length, start, end, display, reload, savefile
+):
     with open(savefile, "r") as stream:
         try:
             dat = yaml.safe_load(stream)
@@ -176,6 +189,30 @@ def reload_query(parser, reload, savefile):
             exit(1)
         cmd = dat[reload]["query"]
     args = parser.parse_args(shlex.split(cmd))  # using shlex to parse string correctly
+
+    print(args)
+
+    # Updating specifc flags for a relaoded query
+
+    if filename is not None:
+        args.filename = filename
+    if wires is not None:
+        args.wires = wires
+    if breakpoints is not None:
+        args.breakpoints = breakpoints
+    if length is not None:
+        args.length = length
+    if start is not None:
+        args.start = start
+    if end is not None:
+        args.end = end
+
+    print(args)
+
+    if length is not None and end is not None:
+        raise SoottyError(
+            f"Length and end flags should not be provided simultaneously."
+        )
 
     compile(
         args.filename,

--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -14,7 +14,7 @@ def main():
         os.makedirs(reload_path)
 
     savefile = reload_path + "queries.yaml"
-    
+
     parser = argparse.ArgumentParser(
         description="Converts .vcd wiretraces to .svg format."
     )

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -18,15 +18,17 @@ def save_query(save, name, wires, br, length, start, end, display):
         else:
             with open(savefile, "w") as stream:
                 if len(lines) >= 500:
-                    print("Saved query limit reached. Deleting least recent query to accommodate new query.", file = sys.stderr)
+                    print(
+                        "Saved query limit reached. Deleting least recent query to accommodate new query.",
+                        file=sys.stderr,
+                    )
                     stream.truncate(0)
                     for key in lines:
                         stat = lines.pop(key)
                         break
-                    # print(lines)
                     if stat is None:  # No lines to delete/Error
                         raise SoottyError("Error deleting least recent query.")
-                    yaml.dump(lines, stream, sort_keys=False)
+                    yaml.dump(lines, stream, sort_keys=False, width=float("inf"))
 
         with open(savefile, "a+") as stream:
             query_write(
@@ -34,6 +36,7 @@ def save_query(save, name, wires, br, length, start, end, display):
             )
 
     else:
+        # Creating new savefile as no savefiles found for sootty
         with open(savefile, "w") as stream:
             query_write(
                 savefile, stream, save, name, wires, br, length, start, end, display
@@ -58,7 +61,7 @@ def query_write(
             )  # Essentially replacing the old query with the new dict
             stream.truncate(0)
             yaml.dump(
-                lines, savefile, sort_keys=False
+                lines, savefile, sort_keys=False, width=float("inf")
             )  # Dumping the overwritten query to the file, forcing no inline output
         else:
             savefile.write(save + ":\n")

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -37,8 +37,9 @@ def query_write(savefile_path, savefile, save, name, wires, br, length, start, e
     with open(savefile_path, "r+") as stream:
         lines = yaml.safe_load(stream) 
         if save in lines:
-            lines[save]["query"] = query_build(name, wires, br, length, start, end, display)
-            lines[save]["date"] = str(datetime.datetime.now())
+            del lines[save]                                          # Deleting outdated query
+            overwrite_dict = {save: {'query': query_build(name, wires, br, length, start, end, display), 'date': str(datetime.datetime.now())}}
+            lines.update(overwrite_dict)                             # Essentially replacing the old query with the new dict
             stream.truncate(0)
             yaml.dump(lines, savefile, sort_keys = False)            # Dumping the overwritten query to the file, forcing no inline output
         else:

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -5,20 +5,30 @@ import yaml
 
 def save_query(save, name, wires, br, length, start, end, display):
     savefile = os.getenv("HOME") + "/.config/sootty/save/queries.yaml"
-    """
-    Memory check for the file
-    """
-    with open(savefile) as f:
-        lines = yaml.safe_load(f)
-        if len(lines) >= 500:
-            stat = lines.popitem(last=False)
-            if stat is None:                                                # No lines to delete/Error
-                raise SoottyError("Error deleting least recent query.")
-            yaml.dump(lines, f, sort_keys = False)
     
     if is_save_file(savefile):
+        """
+        Memory check for the file
+        """
+        with open(savefile, "r") as f:
+            lines = yaml.safe_load(f)
+        if save in lines:
+            pass
+        else:    
+            with open(savefile, "w") as stream:
+                if len(lines) >= 10:
+                    stream.truncate(0)
+                    for key in lines:
+                        stat = lines.pop(key)
+                        break
+                    #print(lines)
+                    if stat is None:                                                # No lines to delete/Error
+                        raise SoottyError("Error deleting least recent query.")
+                    yaml.dump(lines, stream, sort_keys = False)
+
         with open(savefile, "a+") as stream:
             query_write(savefile, stream, save, name, wires, br, length, start, end, display)
+    
     else:
         with open(savefile, "w") as stream:
             query_write(savefile, stream, save, name, wires, br, length, start, end, display)

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -1,28 +1,30 @@
 import os
-
+import datetime
 
 def save_query(save, name, wires, br, length, start, end, display):
-    save = os.getenv("HOME") + "/.config/sootty/save/" + save
+    savefile = os.getenv("HOME") + "/.config/sootty/save.yaml"
     """
     Constructing the query using conditionals
     """
-    with open(save, "w") as wf:
-        wf.truncate(0)
+    with open(savefile, "a") as stream:
+        stream.write(save + ":\n")
+        stream.write("  query:")
         if name:
-            wf.write(' -f "' + name + '"')
+            stream.write(' -f "' + name + '"')
         if wires:
-            wf.write(' -w "' + wires + '"')
+            stream.write(' -w "' + wires + '"')
         if br:
-            wf.write(' -b "' + br + '"')
+            stream.write(' -b "' + br + '"')
         if length:
-            wf.write(' -l "' + str(length) + '"')
+            stream.write(' -l "' + str(length) + '"')
         if start:
-            wf.write(' -s "' + start + '"')
+            stream.write(' -s "' + start + '"')
         if end:
-            wf.write(' -e "' + end + '"')
+            stream.write(' -e "' + end + '"')
         if display:
-            wf.write(" -d")
-
+            stream.write(" -d")
+        stream.write("\n")
+        stream.write("  date: " + str(datetime.datetime.now()) + "\n")
 
 def is_save_file(filename):
     return os.path.isfile(filename)

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -54,38 +54,29 @@ def query_write(
 ):
     with open(savefile_path, "r") as stream:
         lines = yaml.safe_load(stream)
-        if lines is None:
+        if lines is None or (not save in lines):
             savefile.write(save + ":\n")
             savefile.write("  query:")
             savefile.write(query_build(name, wires, br, length, start, end, display))
             savefile.write("\n")
             savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
         else:
-            if save in lines:
-                del lines[save]  # Deleting outdated query
-                overwrite_dict = {
-                    save: {
-                        "query": query_build(
-                            name, wires, br, length, start, end, display
-                        ),
-                        "date": str(datetime.datetime.now()),
-                    }
+            del lines[save]  # Deleting outdated query
+            overwrite_dict = {
+                save: {
+                    "query": query_build(
+                        name, wires, br, length, start, end, display
+                    ),
+                    "date": str(datetime.datetime.now()),
                 }
-                lines.update(
-                    overwrite_dict
-                )  # Essentially replacing the old query with the new dict
-                savefile.truncate(0)
-                yaml.dump(
-                    lines, savefile, sort_keys=False, width=float("inf")
-                )  # Dumping the overwritten query to the file, forcing no inline output
-            else:
-                savefile.write(save + ":\n")
-                savefile.write("  query:")
-                savefile.write(
-                    query_build(name, wires, br, length, start, end, display)
-                )
-                savefile.write("\n")
-                savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
+            }
+            lines.update(
+                overwrite_dict
+            )  # Essentially replacing the old query with the new dict
+            savefile.truncate(0)
+            yaml.dump(
+                lines, savefile, sort_keys=False, width=float("inf")
+            )  # Dumping the overwritten query to the file, forcing no inline output
 
 
 def query_build(name, wires, br, length, start, end, display):

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -91,7 +91,7 @@ def query_build(name, wires, br, length, start, end, display):
     if br:
         cmd += f' -b "{br}"'
     if length:
-        cmd += f' -l "{str(length)}"'
+        cmd += f' -l "{length}"'
     if start:
         cmd += f' -s "{start}"'
     if end:

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -22,18 +22,18 @@ def save_query(save, name, wires, br, length, start, end, display):
             if save in lines:
                 pass
             else:
-                    if len(lines) >= 500:
-                        print(
-                            "Saved query limit reached. Deleting least recent query to accommodate new query.",
-                            file=sys.stderr,
-                        )
-                        f.truncate(0)
-                        for key in lines:
-                            stat = lines.pop(key)
-                            break
-                        if stat is None:  # No lines to delete/Error
-                            raise SoottyError("Error deleting least recent query.")
-                        yaml.dump(lines, f, sort_keys=False, width=float("inf"))
+                if len(lines) >= 500:
+                    print(
+                        "Saved query limit reached. Deleting least recent query to accommodate new query.",
+                        file=sys.stderr,
+                    )
+                    f.truncate(0)
+                    for key in lines:
+                        stat = lines.pop(key)
+                        break
+                    if stat is None:  # No lines to delete/Error
+                        raise SoottyError("Error deleting least recent query.")
+                    yaml.dump(lines, f, sort_keys=False, width=float("inf"))
 
             with open(savefile, "a+") as stream:
                 query_write(
@@ -65,7 +65,9 @@ def query_write(
                 del lines[save]  # Deleting outdated query
                 overwrite_dict = {
                     save: {
-                        "query": query_build(name, wires, br, length, start, end, display),
+                        "query": query_build(
+                            name, wires, br, length, start, end, display
+                        ),
                         "date": str(datetime.datetime.now()),
                     }
                 }
@@ -79,7 +81,9 @@ def query_write(
             else:
                 savefile.write(save + ":\n")
                 savefile.write("  query:")
-                savefile.write(query_build(name, wires, br, length, start, end, display))
+                savefile.write(
+                    query_build(name, wires, br, length, start, end, display)
+                )
                 savefile.write("\n")
                 savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
 

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -1,11 +1,19 @@
 import os
+import subprocess
 import datetime
 
 def save_query(save, name, wires, br, length, start, end, display):
     savefile = os.getenv("HOME") + "/.config/sootty/save/queries.yaml"
     """
-    Constructing the query using conditionals
+    Memory check for the file
     """
+    with open(savefile) as f:
+        count = sum(1 for _ in f)
+        if count >= 1500:
+            status = subprocess.run("sed -i 1,3d " + savefile, shell=True)  # Deleting first 3 lines using sed instead of reading all lines
+            if status.returncode != 0:                                      # sed operation failed
+                raise Exception("Error deleting least recent query.")
+                
     if is_save_file(savefile):
         with open(savefile, "a") as stream:
             query_write(stream, save, name, wires, br, length, start, end, display)
@@ -16,6 +24,9 @@ def save_query(save, name, wires, br, length, start, end, display):
 def query_write(savefile, save, name, wires, br, length, start, end, display):
     savefile.write(save + ":\n")
     savefile.write("  query:")
+    """
+    Constructing the query using conditionals
+    """  
     if name:
         savefile.write(' -f "' + name + '"')
     if wires:

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 from sootty.exceptions import SoottyError
 import datetime
 import yaml
@@ -17,7 +17,8 @@ def save_query(save, name, wires, br, length, start, end, display):
             pass
         else:
             with open(savefile, "w") as stream:
-                if len(lines) >= 10:
+                if len(lines) >= 500:
+                    print("Saved query limit reached. Deleting least recent query to accommodate new query.", file = sys.stderr)
                     stream.truncate(0)
                     for key in lines:
                         stat = lines.pop(key)

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+from sootty.exceptions import SoottyError
 import datetime
 import yaml
 
@@ -9,12 +9,13 @@ def save_query(save, name, wires, br, length, start, end, display):
     Memory check for the file
     """
     with open(savefile) as f:
-        count = sum(1 for _ in f)
-        if count >= 1500:
-            status = subprocess.run("sed -i 1,3d " + savefile, shell=True)  # Deleting first 3 lines using sed instead of reading all lines
-            if status.returncode != 0:                                      # sed operation failed
-                raise Exception("Error deleting least recent query.")
-                
+        lines = yaml.safe_load(f)
+        if len(lines) >= 500:
+            stat = lines.popitem(last=False)
+            if stat is None:                                                # No lines to delete/Error
+                raise SoottyError("Error deleting least recent query.")
+            yaml.dump(lines, f, sort_keys = False)
+    
     if is_save_file(savefile):
         with open(savefile, "a+") as stream:
             query_write(savefile, stream, save, name, wires, br, length, start, end, display)
@@ -29,15 +30,13 @@ def query_write(savefile_path, savefile, save, name, wires, br, length, start, e
             lines[save]["query"] = query_build(name, wires, br, length, start, end, display)
             lines[save]["date"] = str(datetime.datetime.now())
             stream.truncate(0)
-            res = sorted(lines.items(), key = lambda x: x[1]["date"])
-            print(res)
-            #yaml.dump(lines, savefile)            # Dumping the overwritten query to the file, forcing no inline output
-            exit(0)
-    savefile.write(save + ":\n")
-    savefile.write("  query:")    
-    savefile.write(query_build(name, wires, br, length, start, end, display))
-    savefile.write("\n")
-    savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
+            yaml.dump(lines, savefile, sort_keys = False)            # Dumping the overwritten query to the file, forcing no inline output
+        else:
+            savefile.write(save + ":\n")
+            savefile.write("  query:")    
+            savefile.write(query_build(name, wires, br, length, start, end, display))
+            savefile.write("\n")
+            savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
 
 def query_build(name, wires, br, length, start, end, display):
     """

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -2,29 +2,37 @@ import os
 import datetime
 
 def save_query(save, name, wires, br, length, start, end, display):
-    savefile = os.getenv("HOME") + "/.config/sootty/save.yaml"
+    savefile = os.getenv("HOME") + "/.config/sootty/save/queries.yaml"
     """
     Constructing the query using conditionals
     """
-    with open(savefile, "a") as stream:
-        stream.write(save + ":\n")
-        stream.write("  query:")
-        if name:
-            stream.write(' -f "' + name + '"')
-        if wires:
-            stream.write(' -w "' + wires + '"')
-        if br:
-            stream.write(' -b "' + br + '"')
-        if length:
-            stream.write(' -l "' + str(length) + '"')
-        if start:
-            stream.write(' -s "' + start + '"')
-        if end:
-            stream.write(' -e "' + end + '"')
-        if display:
-            stream.write(" -d")
-        stream.write("\n")
-        stream.write("  date: " + str(datetime.datetime.now()) + "\n")
+    if is_save_file(savefile):
+        with open(savefile, "a") as stream:
+            query_write(stream, save, name, wires, br, length, start, end, display)
+    else:
+        with open(savefile, "w") as stream:
+            query_write(stream, save, name, wires, br, length, start, end, display)
+
+def query_write(savefile, save, name, wires, br, length, start, end, display):
+    savefile.write(save + ":\n")
+    savefile.write("  query:")
+    if name:
+        savefile.write(' -f "' + name + '"')
+    if wires:
+        savefile.write(' -w "' + wires + '"')
+    if br:
+        savefile.write(' -b "' + br + '"')
+    if length:
+        savefile.write(' -l "' + str(length) + '"')
+    if start:
+        savefile.write(' -s "' + start + '"')
+    if end:
+        savefile.write(' -e "' + end + '"')
+    if display:
+        savefile.write(" -d")
+    savefile.write("\n")
+    savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
+
 
 def is_save_file(filename):
     return os.path.isfile(filename)

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -77,19 +77,19 @@ def query_build(name, wires, br, length, start, end, display):
     """
     cmd = ""
     if name:
-        cmd += ' -f "' + name + '"'
+        cmd += f' -f "{name}"'
     if wires:
-        cmd += ' -w "' + wires + '"'
+        cmd += f' -w "{wires}"'
     if br:
-        cmd += ' -b "' + br + '"'
+        cmd += f' -b "{br}"'
     if length:
-        cmd += ' -l "' + str(length) + '"'
+        cmd += f' -l "{str(length)}"'
     if start:
-        cmd += ' -s "' + start + '"'
+        cmd += f' -s "{start}"'
     if end:
-        cmd += ' -e "' + end + '"'
+        cmd += f' -e "{end}"'
     if display:
-        cmd += " -d"
+        cmd += f" -d"
     return cmd
 
 

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -3,9 +3,10 @@ from sootty.exceptions import SoottyError
 import datetime
 import yaml
 
+
 def save_query(save, name, wires, br, length, start, end, display):
     savefile = os.getenv("HOME") + "/.config/sootty/save/queries.yaml"
-    
+
     if is_save_file(savefile):
         """
         Memory check for the file
@@ -14,40 +15,57 @@ def save_query(save, name, wires, br, length, start, end, display):
             lines = yaml.safe_load(f)
         if save in lines:
             pass
-        else:    
+        else:
             with open(savefile, "w") as stream:
                 if len(lines) >= 10:
                     stream.truncate(0)
                     for key in lines:
                         stat = lines.pop(key)
                         break
-                    #print(lines)
-                    if stat is None:                                                # No lines to delete/Error
+                    # print(lines)
+                    if stat is None:  # No lines to delete/Error
                         raise SoottyError("Error deleting least recent query.")
-                    yaml.dump(lines, stream, sort_keys = False)
+                    yaml.dump(lines, stream, sort_keys=False)
 
         with open(savefile, "a+") as stream:
-            query_write(savefile, stream, save, name, wires, br, length, start, end, display)
-    
+            query_write(
+                savefile, stream, save, name, wires, br, length, start, end, display
+            )
+
     else:
         with open(savefile, "w") as stream:
-            query_write(savefile, stream, save, name, wires, br, length, start, end, display)
+            query_write(
+                savefile, stream, save, name, wires, br, length, start, end, display
+            )
 
-def query_write(savefile_path, savefile, save, name, wires, br, length, start, end, display):
+
+def query_write(
+    savefile_path, savefile, save, name, wires, br, length, start, end, display
+):
     with open(savefile_path, "r+") as stream:
-        lines = yaml.safe_load(stream) 
+        lines = yaml.safe_load(stream)
         if save in lines:
-            del lines[save]                                          # Deleting outdated query
-            overwrite_dict = {save: {'query': query_build(name, wires, br, length, start, end, display), 'date': str(datetime.datetime.now())}}
-            lines.update(overwrite_dict)                             # Essentially replacing the old query with the new dict
+            del lines[save]  # Deleting outdated query
+            overwrite_dict = {
+                save: {
+                    "query": query_build(name, wires, br, length, start, end, display),
+                    "date": str(datetime.datetime.now()),
+                }
+            }
+            lines.update(
+                overwrite_dict
+            )  # Essentially replacing the old query with the new dict
             stream.truncate(0)
-            yaml.dump(lines, savefile, sort_keys = False)            # Dumping the overwritten query to the file, forcing no inline output
+            yaml.dump(
+                lines, savefile, sort_keys=False
+            )  # Dumping the overwritten query to the file, forcing no inline output
         else:
             savefile.write(save + ":\n")
-            savefile.write("  query:")    
+            savefile.write("  query:")
             savefile.write(query_build(name, wires, br, length, start, end, display))
             savefile.write("\n")
             savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
+
 
 def query_build(name, wires, br, length, start, end, display):
     """
@@ -69,6 +87,7 @@ def query_build(name, wires, br, length, start, end, display):
     if display:
         cmd += " -d"
     return cmd
+
 
 def is_save_file(filename):
     return os.path.isfile(filename)

--- a/sootty/save.py
+++ b/sootty/save.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import datetime
+import yaml
 
 def save_query(save, name, wires, br, length, start, end, display):
     savefile = os.getenv("HOME") + "/.config/sootty/save/queries.yaml"
@@ -15,35 +16,49 @@ def save_query(save, name, wires, br, length, start, end, display):
                 raise Exception("Error deleting least recent query.")
                 
     if is_save_file(savefile):
-        with open(savefile, "a") as stream:
-            query_write(stream, save, name, wires, br, length, start, end, display)
+        with open(savefile, "a+") as stream:
+            query_write(savefile, stream, save, name, wires, br, length, start, end, display)
     else:
         with open(savefile, "w") as stream:
-            query_write(stream, save, name, wires, br, length, start, end, display)
+            query_write(savefile, stream, save, name, wires, br, length, start, end, display)
 
-def query_write(savefile, save, name, wires, br, length, start, end, display):
+def query_write(savefile_path, savefile, save, name, wires, br, length, start, end, display):
+    with open(savefile_path, "r+") as stream:
+        lines = yaml.safe_load(stream) 
+        if save in lines:
+            lines[save]["query"] = query_build(name, wires, br, length, start, end, display)
+            lines[save]["date"] = str(datetime.datetime.now())
+            stream.truncate(0)
+            res = sorted(lines.items(), key = lambda x: x[1]["date"])
+            print(res)
+            #yaml.dump(lines, savefile)            # Dumping the overwritten query to the file, forcing no inline output
+            exit(0)
     savefile.write(save + ":\n")
-    savefile.write("  query:")
-    """
-    Constructing the query using conditionals
-    """  
-    if name:
-        savefile.write(' -f "' + name + '"')
-    if wires:
-        savefile.write(' -w "' + wires + '"')
-    if br:
-        savefile.write(' -b "' + br + '"')
-    if length:
-        savefile.write(' -l "' + str(length) + '"')
-    if start:
-        savefile.write(' -s "' + start + '"')
-    if end:
-        savefile.write(' -e "' + end + '"')
-    if display:
-        savefile.write(" -d")
+    savefile.write("  query:")    
+    savefile.write(query_build(name, wires, br, length, start, end, display))
     savefile.write("\n")
     savefile.write("  date: " + str(datetime.datetime.now()) + "\n")
 
+def query_build(name, wires, br, length, start, end, display):
+    """
+    Constructing the query using conditionals
+    """
+    cmd = ""
+    if name:
+        cmd += ' -f "' + name + '"'
+    if wires:
+        cmd += ' -w "' + wires + '"'
+    if br:
+        cmd += ' -b "' + br + '"'
+    if length:
+        cmd += ' -l "' + str(length) + '"'
+    if start:
+        cmd += ' -s "' + start + '"'
+    if end:
+        cmd += ' -e "' + end + '"'
+    if display:
+        cmd += " -d"
+    return cmd
 
 def is_save_file(filename):
     return os.path.isfile(filename)


### PR DESCRIPTION
With this PR, all the queries are saved in a `queries.yaml` file in the `~/.config/sootty/save` directory. All the queries are sorted by date, and are stored in a nested dictionary format. 

Each query has a key which is given by the user, the query itself, and the date and time at which the query was last accessed/reloaded. Partial reloading of queries has also been implemented.