### PR TITLE
Create example4.evcd

### DIFF
--- a/example/example4.evcd
+++ b/example/example4.evcd
@@ -1,0 +1,37 @@
+$scope module testbench.adder_instance $end
+$var port 1 <0 data0 $end
+$var port 1 <1 data1 $end
+$var port 1 <2 data2 $end
+$var port 1 <3 data3 $end
+$var port 1 <4 carry $end
+$var port 1 <5 as $end
+$var port 1 <6 rdn $end
+$var port 1 <7 reset $end
+$var port 1 <8 test $end
+$var port 1 <9 write $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpports
+pX 6 6 <0
+pX 6 6 <1
+pX 6 6 <2
+pX 6 6 <3
+pX 6 6 <4
+pN 6 6 <5
+pN 6 6 <6
+pU 0 6 <7
+pD 6 0 <8
+pN 6 6 <9
+$end
+#18
+pH 0 6 <4
+#20
+pD 6 0 <5
+pU 0 6 <6
+pD 6 0 <9
+#25
+pf 0 0 <0
+pf 0 0 <1
+pf 0 0 <2
+pf 0 0 <3


### PR DESCRIPTION
The example is retrieved from 1800-2017 IEEE Standard for SystemVerilog -- Unified Hardware Design, Specification, and Verification Language 21.7.4.4 Extended VCD file format example (pp. 671-672). The example omits $date, $version, $comment, $timescale, etc. because their syntaxe is the same for VCD and EVCD. The timestamps are changed to small numbers to help demonstration.