### PR TITLE
Fixed bug where logical or breaks query

### DIFF
--- a/sootty/limits.py
+++ b/sootty/limits.py
@@ -1,4 +1,5 @@
 from lark import Lark, Tree, Token, Visitor
+import sys
 
 try:
     import importlib.resources as pkg_resources
@@ -69,3 +70,7 @@ class LimitExpression:
     def __init__(self, expression):
         parsed = parser.parse(expression)
         self.tree = Prune().visit(parsed)
+
+    def display(self):
+        """Display parse tree for debugging purposes."""
+        print(self.tree.pretty(), file=sys.stderr)

--- a/sootty/storage/wire.py
+++ b/sootty/storage/wire.py
@@ -96,6 +96,7 @@ class Wire:
     def _logical_or(self, other):
         wire = Wire(name="(" + self.name + " || " + other.name + ")")
         wire._data = self._data._to_bool().__or__(other._data._to_bool())
+        return wire
 
     def __eq__(self, other):
         wire = Wire(name="(" + self.name + " == " + other.name + ")")

--- a/sootty/storage/wiretrace.py
+++ b/sootty/storage/wiretrace.py
@@ -160,9 +160,7 @@ class WireTrace:
         return self.root.get_names()
 
     def _compute_wire(self, node):
-        """
-        Evaluate a limit expression
-        """
+        """Evaluate a limit expression"""
         if node.data == "wire":
             return self.find(node.children[0])
         elif node.data.type == "NEG":
@@ -184,13 +182,13 @@ class WireTrace:
         elif node.data.type == "LNOT":
             return self._compute_wire(node.children[0])._logical_not()
         elif node.data.type == "LAND":
-            return self._compute_wire(node.children[0])._logical_and(self._compute_wire(
-                node.children[1]
-            ))
+            return self._compute_wire(node.children[0])._logical_and(
+                self._compute_wire(node.children[1])
+            )
         elif node.data.type == "LOR":
-            return self._compute_wire(node.children[0])._logical_or(self._compute_wire(
-                node.children[1]
-            ))
+            return self._compute_wire(node.children[0])._logical_or(
+                self._compute_wire(node.children[1])
+            )
         elif node.data.type == "EQ":
             return self._compute_wire(node.children[0]) == self._compute_wire(
                 node.children[1]
@@ -253,7 +251,7 @@ class WireTrace:
             return Wire.const(int(node.children[0]))
         elif node.data.type == "TIME":
             return Wire.time(int(node.children[0]))
-    
+
     def compute_wire(self, expr: str):
         """Evaluate a limit expression"""
         return self._compute_wire(LimitExpression(expr).tree)


### PR DESCRIPTION
The bug was triggered with the command:

    sootty example/example3.vcd -b "before time 10 || after time 12" -w "pc" -e "time 20"

It should display properly now.