### PR TITLE
WireGroup's get_names for different scopes

### DIFF
--- a/sootty/storage/wiregroup.py
+++ b/sootty/storage/wiregroup.py
@@ -40,9 +40,16 @@ class WireGroup:
 
     def get_names(self):
         """Returns list of all wire names."""
-        names = set()
-        for wire in self.wires:
-            names.add(wire.name)
-        for group in self.groups:
-            names.update(group.get_names())
+        if self.groups:
+            names = dict()
+            if self.wires:
+                names[self.name] = list()
+                for wire in self.wires:
+                    names[self.name].append(wire.name)
+            for group in self.groups:
+                names[group.name] = group.get_names()
+        else:
+            names = list()
+            for wire in self.wires:
+                names.append(wire.name)
         return names


### PR DESCRIPTION
Previously `get_name` will regard all wires with the same name as the same wires, which is an oversimplification. Now, wire names are associated with their wire groups.