### PR TITLE
Implement function call syntax

### DIFF
--- a/sootty/__main__.py
+++ b/sootty/__main__.py
@@ -141,9 +141,6 @@ def main():
     if breakpoints is not None:
         breakpoints = wiretrace.evaluate(breakpoints)
 
-    if wires is not None:
-        wires = set([name.strip() for name in wires.split(",")])
-
     # Convert wiretrace to graphical vector image.
     image = Visualizer().to_svg(
         wiretrace,
@@ -154,10 +151,12 @@ def main():
         vector_radix=radix,
     )
 
-    if wires is not None and len(wires):
-        raise Exception(
-            f"Unknown wires {wires.__repr__()}\nThe following wires were detected in the wiretrace:\n{wiretrace.get_wire_names()}"
-        )
+    # This was the previous way of handling invalid wire names. It is no longer needed,
+    # but I'm keeping it here as a reminder to review the error handling system.
+    # if wires is not None and len(wires):
+    #     raise Exception(
+    #         f"Unknown wires {wires.__repr__()}\nThe following wires were detected in the wiretrace:\n{wiretrace.get_wire_names()}"
+    #     )
 
     if not output:
         image.display()  # Show image in terminal (works in kitty, iterm)

--- a/sootty/static/grammar.lark
+++ b/sootty/static/grammar.lark
@@ -4,8 +4,7 @@
 %import common.DIGIT -> DIGIT
 %import common.NUMBER -> NUM
 
-start : lexp
-NAME: ("_"|LETTER) ("_"|LETTER|DIGIT)* ("." ("_"|LETTER|DIGIT)+)*
+NAME : ("_"|LETTER) ("_"|LETTER|DIGIT)* ("." ("_"|LETTER|DIGIT)+)*
 
 AND : "&"
 OR : "|"
@@ -58,5 +57,12 @@ uop : INV | NEG | NOT
 type : CONST | TIME
 top : FROM | AFTER | UNTIL | BEFORE
 tsop : NEXT | PREV
-wire : NAME | "(" lexp ")" | uop wire | type NUM 
-    | top wire | tsop wire | NUM tsop wire | ACC wire
+
+call : NAME "(" args ")"
+args : wire ("," wire)*
+
+wire : NAME | "(" lexp ")" | uop wire | type NUM | top wire | tsop wire 
+    | NUM tsop wire | ACC wire | call
+
+expr : lexp
+exprs : expr ("," expr)*

--- a/sootty/visualizer.py
+++ b/sootty/visualizer.py
@@ -71,13 +71,27 @@ class Visualizer:
         wiretrace,
         start=0,
         length=None,
-        wires=None,
+        wires="",
         breakpoints=None,
         vector_radix=10,
     ):
+        """
+        Converts the provided wiretrace object to a VectorImage object (svg).
+
+        :param wires: comma-seperated list of wires to include
+        """
         if length is None:
             length = wiretrace.length()
-        """Converts the provided wiretrace object to a VectorImage object (svg)."""
+
+        if wires:  # include all wires if empty list provided
+            wires = (
+                None
+                if len(wires) == 0
+                else set(
+                    map(lambda wire: wire.name, wiretrace.compute_wires(wires.strip()))
+                )
+            )
+
         return VectorImage(
             self._wiretrace_to_svg(
                 wiretrace, start, length, wires, breakpoints, vector_radix
@@ -87,11 +101,10 @@ class Visualizer:
     def _wiretrace_to_svg(
         self, wiretrace, start, length, wires=None, breakpoints=None, vector_radix=10
     ):
-        if wires and len(wires) == 0:  # include all wires if empty list provided
-            wires = None
         width = (
             2 * self.style.LEFT_MARGIN + self.style.TEXT_WIDTH + self.style.FULL_WIDTH
         )
+
         height = (
             2 * self.style.TOP_MARGIN
             - self.style.WIRE_MARGIN


### PR DESCRIPTION
This PR adds syntax to the query language for function calls `function ( arg1, arg2, ... )` as well as fixing bugs with the `-w` flag caused by the addition of commas to the query language.